### PR TITLE
More reliable gvt restore

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,11 +12,10 @@ IMAGE := $(REGISTRY)/$(APP):$(BUILD_NUM)
 
 # deps
 gvt_install:  ## install the gvt util
-		go get -u github.com/FiloSottile/gvt
+	go get -u github.com/FiloSottile/gvt
 
 deps: gvt_install
-	find  ./vendor/* -maxdepth 0 -type d -exec rm -rf "{}" \;
-	gvt rebuild
+	gvt rebuild || true
 
 cover_deps:
 	go get github.com/pierrre/gotestcover
@@ -29,6 +28,7 @@ ifeq ($(CIRCLECI), true)
 	go env
 endif
 	go test -v $$(go list ./... | grep -v /vendor/)
+	go build -v -race
 
 cov: cover_deps ## generate coverage report (coverage.out)
 	gotestcover -coverprofile=coverage.out $$(go list ./... | grep -v /vendor/)

--- a/circle.yml
+++ b/circle.yml
@@ -14,7 +14,7 @@ dependencies:
   cache_directories:
     - ../google-cloud-sdk
     - ../go_workspace
-    - ../go1.6
+    - ../go1.6.2
     - vendor
 
   override:


### PR DESCRIPTION
GVT restore sometimes fails on recursive deps that already have been downloaded. For now We will let build fail instead of the deps fail on this condition. 

Ideally gvt wouldn't have this issue which may be a race ?
